### PR TITLE
Use this mode for .env.example

### DIFF
--- a/dotenv-mode.el
+++ b/dotenv-mode.el
@@ -87,6 +87,7 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.env\\'" . dotenv-mode))
+(add-to-list 'auto-mode-alist '("\\.env\\.example\\'" . dotenv-mode))
 
 (provide 'dotenv-mode)
 


### PR DESCRIPTION
It is common to store `.env.example` in git as an example/list of all possible options/variables.  Since it is an env file fundamentally let's use this mode for these as well.